### PR TITLE
fix(bucketeer): user id validation

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -151,5 +151,5 @@ func (a *exampleApp) userFrom(r *http.Request) (*bucketeer.User, error) {
 		}
 		userID = uuid.String()
 	}
-	return bucketeer.NewUser(userID, nil)
+	return bucketeer.NewUser(userID, nil), nil
 }

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -218,6 +218,9 @@ func (s *sdk) JSONVariation(ctx context.Context, user *User, featureID string, d
 }
 
 func (s *sdk) getEvaluation(ctx context.Context, user *User, featureID string) (*protofeature.Evaluation, error) {
+	if !user.Valid() {
+		return nil, fmt.Errorf("invalid user: %v", user)
+	}
 	req := &protogateway.GetEvaluationRequest{
 		Tag:       s.tag,
 		User:      user.User,
@@ -274,6 +277,14 @@ func (s *sdk) Track(ctx context.Context, user *User, goalID string) {
 }
 
 func (s *sdk) TrackValue(ctx context.Context, user *User, goalID string, value float64) {
+	if !user.Valid() {
+		s.loggers.Errorf("bucketeer: failed to track due to invalid user (user: %v, goalID: %v, value: %g)",
+			user,
+			goalID,
+			value,
+		)
+		return
+	}
 	s.eventProcessor.PushGoalEvent(ctx, user.User, goalID, value)
 }
 

--- a/pkg/bucketeer/user.go
+++ b/pkg/bucketeer/user.go
@@ -1,8 +1,6 @@
 package bucketeer
 
 import (
-	"errors"
-
 	protouser "github.com/ca-dp/bucketeer-go-server-sdk/proto/user"
 )
 
@@ -16,12 +14,20 @@ type User struct {
 // NewUser creates a new User.
 //
 // id is mandatory and attributes is optional.
-func NewUser(id string, attributes map[string]string) (*User, error) {
-	if id == "" {
-		return nil, errors.New("bucketeer: user id is empty")
-	}
+func NewUser(id string, attributes map[string]string) *User {
 	return &User{User: &protouser.User{
 		Id:   id,
 		Data: attributes,
-	}}, nil
+	}}
+}
+
+// Valid returns true if valid user, otherwise returns false.
+func (u *User) Valid() bool {
+	if u == nil {
+		return false
+	}
+	if u.Id == "" {
+		return false
+	}
+	return true
 }

--- a/pkg/bucketeer/user_test.go
+++ b/pkg/bucketeer/user_test.go
@@ -4,57 +4,41 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	protouser "github.com/ca-dp/bucketeer-go-server-sdk/proto/user"
 )
 
-func TestNewUser(t *testing.T) {
+func TestValid(t *testing.T) {
 	t.Parallel()
 	userID := "user-id"
 	userAttrs := map[string]string{"foo": "bar"}
 	tests := []struct {
-		desc       string
-		id         string
-		attributes map[string]string
-		expected   *User
-		isErr      bool
+		desc  string
+		user  *User
+		valid bool
 	}{
 		{
-			desc:       "error: empty id",
-			id:         "",
-			attributes: nil,
-			expected:   nil,
-			isErr:      true,
+			desc:  "return false when user is nil",
+			user:  nil,
+			valid: false,
 		},
 		{
-			desc:       "user without attributes",
-			id:         userID,
-			attributes: nil,
-			expected: &User{User: &protouser.User{
-				Id: userID,
-			}},
-			isErr: false,
+			desc:  "return false when user id is empty",
+			user:  NewUser("", nil),
+			valid: false,
 		},
 		{
-			desc:       "user with attributes",
-			id:         userID,
-			attributes: userAttrs,
-			expected: &User{User: &protouser.User{
-				Id:   userID,
-				Data: userAttrs,
-			}},
-			isErr: false,
+			desc:  "return true when user attributes is nil",
+			user:  NewUser(userID, nil),
+			valid: true,
+		},
+		{
+			desc:  "return true",
+			user:  NewUser(userID, userAttrs),
+			valid: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			u, err := NewUser(tt.id, tt.attributes)
-			if tt.isErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.expected, u)
+			assert.Equal(t, tt.valid, tt.user.Valid())
 		})
 	}
 }

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -23,8 +23,7 @@ func TestGetEvaluation(t *testing.T) {
 	defer client.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	user, err := bucketeer.NewUser(userID, nil)
-	require.NoError(t, err)
+	user := bucketeer.NewUser(userID, nil)
 	req := &protogateway.GetEvaluationRequest{
 		Tag:       tag,
 		User:      user.User,
@@ -42,8 +41,7 @@ func TestRegisterEvents(t *testing.T) {
 	defer client.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	user, err := bucketeer.NewUser(userID, nil)
-	require.NoError(t, err)
+	user := bucketeer.NewUser(userID, nil)
 	evaluationEvent, err := ptypes.MarshalAny(&protoevent.EvaluationEvent{
 		Timestamp:      time.Now().Unix(),
 		FeatureId:      featureID,

--- a/test/e2e/sdk_test.go
+++ b/test/e2e/sdk_test.go
@@ -71,7 +71,5 @@ func newSDK(t *testing.T, ctx context.Context) bucketeer.SDK {
 
 func newUser(t *testing.T, id string) *bucketeer.User {
 	t.Helper()
-	user, err := bucketeer.NewUser(id, map[string]string{"attr-key": "attr-value"})
-	require.NoError(t, err)
-	return user
+	return bucketeer.NewUser(id, map[string]string{"attr-key": "attr-value"})
 }


### PR DESCRIPTION
To make it easy to use the sdk, don't return error from NewUser.
Instead, add a validation to SDK methods.