### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/pr-title-validation.yaml
+++ b/.github/workflows/pr-title-validation.yaml
@@ -1,0 +1,39 @@
+name: "pr-title-validation"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  validate_pr_title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7 #v4.6.0
+        with:
+          # Use the following release types to match the same rules in the PR title lint
+          # https://github.com/googleapis/release-please/blob/main/src/changelog-notes.ts#L42-L55
+          types: |
+            feat
+            fix
+            perf
+            deps
+            revert
+            docs
+            style
+            chore
+            refactor
+            test
+            build
+            ci
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@2a4590f9c1d322790253d997de5cad7f7ad4bc1b # v3.5.1
+        with:
+          changelog-types: |
+            [
+              {"type":"build","section":"Build System","hidden":false},
+              {"type":"chore","section":"Miscellaneous","hidden":false},
+              {"type":"feat","section":"Features","hidden":false},
+              {"type":"fix","section":"Bug Fixes","hidden":false},
+              {"type":"perf","section":"Performance Improvements","hidden":false},
+              {"type":"revert","section":"Reverts","hidden":false}
+            ]
+          release-type: simple
+          package-name: bucketeer-go-server-sdk
+          bump-minor-pre-major: true
+          extra-files: |
+            pkg/bucketeer/version.go
+    

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 #############################
 # Variables
 #############################
-PROTO_TOP_DIR := $(shell cd ../bucketeer && pwd)
-PROTOBUF_INCLUDE_DIR := ${PROTO_TOP_DIR}/proto/external/protocolbuffers/protobuf/v3.9.0
-PROTO_FOLDERS := event/client feature gateway user
-PROTO_OUTPUT := proto_output
-IMPORT_PATH_FROM := github.com/ca-dp/bucketeer
 IMPORT_PATH_TO := github.com/ca-dp/bucketeer-go-server-sdk
 
 #############################
@@ -52,26 +47,3 @@ coverage:
 e2e:
 	go test -race ./test/e2e/... \
 		-args -api-key=${API_KEY} -host=${HOST} -port=${PORT}
-
-#############################
-# Proto
-#############################
-.PHONY: copy-protos
-copy-protos: .gen-protos
-	rm -rf proto
-	mv ${PROTO_OUTPUT}/${IMPORT_PATH_FROM}/proto .
-
-.PHONY: .gen-protos
-.gen-protos:
-	if [ -d ${PROTO_OUTPUT} ]; then rm -fr ${PROTO_OUTPUT}; fi; \
-	mkdir ${PROTO_OUTPUT}; \
-	for f in ${PROTO_FOLDERS}; do \
-		protoc -I"${PROTO_TOP_DIR}" \
-			-I"${PROTOBUF_INCLUDE_DIR}" \
-			-I"${GOPATH}/src/github.com/googleapis/googleapis" \
-			--go_out=plugins=grpc:./${PROTO_OUTPUT} \
-			${PROTO_TOP_DIR}/proto/$$f/*.proto; \
-	done; \
-	for file in $$(find ./${PROTO_OUTPUT} -name "*.go"); do \
-		sed -i '' 's|${IMPORT_PATH_FROM}|${IMPORT_PATH_TO}|g' $$file; \
-	done

--- a/pkg/bucketeer/version/version.go
+++ b/pkg/bucketeer/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// x-release-please-start-version
+
+const SDKVersion = "1.3.3"
+
+// x-release-please-start-end


### PR DESCRIPTION
- added `pr-title-validation` and `release` workflows.
  - `pkg/bucketeer/version/version.go` can be updated according to the release version.
  - Issue: https://github.com/ca-dp/bucketeer/issues/3963
- removed proto rules from Makefile.