### PR TITLE
chore: support LatencySecond field

### DIFF
--- a/pkg/bucketeer/event/processor.go
+++ b/pkg/bucketeer/event/processor.go
@@ -209,8 +209,7 @@ func (p *processor) PushGoalEvent(ctx context.Context, user *user.User, GoalID s
 }
 
 func (p *processor) PushLatencyMetricsEvent(ctx context.Context, duration time.Duration, api model.APIID) {
-	val := fmt.Sprintf("%ds", duration.Microseconds()/1000)
-	gelMetricsEvt := model.NewLatencyMetricsEvent(p.tag, val, api)
+	gelMetricsEvt := model.NewLatencyMetricsEvent(p.tag, duration.Seconds(), api)
 	encodedGELMetricsEvt, err := json.Marshal(gelMetricsEvt)
 	if err != nil {
 		p.loggers.Errorf("bucketeer/event: PushLatencyMetricsEvent failed (err: %v, tag: %s)", err, p.tag)

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -106,7 +106,7 @@ func TestPushLatencyMetricsEvent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, model.GetEvaluation, gelMetricsEvt.APIID)
 	assert.Equal(t, p.tag, gelMetricsEvt.Labels["tag"])
-	assert.Equal(t, &model.Duration{Type: model.DurationType, Value: "86400000s"}, gelMetricsEvt.Duration)
+	assert.Equal(t, t2.Sub(t1).Seconds(), gelMetricsEvt.LatencySecond)
 	assert.Equal(t, model.LatencyMetricsEventType, gelMetricsEvt.Type)
 }
 

--- a/pkg/bucketeer/model/latency_metrics_event.go
+++ b/pkg/bucketeer/model/latency_metrics_event.go
@@ -1,23 +1,20 @@
 package model
 
 type LatencyMetricsEvent struct {
-	APIID    APIID                  `json:"apiId,omitempty"`
-	Labels   map[string]string      `json:"labels,omitempty"`
-	Duration *Duration              `json:"duration,omitempty"`
-	Type     metricsDetailEventType `json:"@type,omitempty"`
+	APIID         APIID                  `json:"apiId,omitempty"`
+	Labels        map[string]string      `json:"labels,omitempty"`
+	LatencySecond float64                `json:"latencySecond,omitempty"`
+	Type          metricsDetailEventType `json:"@type,omitempty"`
 }
 
 //nolint:lll
 const LatencyMetricsEventType metricsDetailEventType = "type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent"
 
-func NewLatencyMetricsEvent(tag, val string, api APIID) *LatencyMetricsEvent {
+func NewLatencyMetricsEvent(tag string, second float64, api APIID) *LatencyMetricsEvent {
 	return &LatencyMetricsEvent{
-		APIID:  api,
-		Labels: map[string]string{"tag": tag},
-		Duration: &Duration{
-			Type:  DurationType,
-			Value: val,
-		},
-		Type: LatencyMetricsEventType,
+		APIID:         api,
+		Labels:        map[string]string{"tag": tag},
+		LatencySecond: second,
+		Type:          LatencyMetricsEventType,
 	}
 }

--- a/pkg/bucketeer/model/latency_metrics_event_test.go
+++ b/pkg/bucketeer/model/latency_metrics_event_test.go
@@ -8,10 +8,9 @@ import (
 
 func TestNewLatencyMetricsEvent(t *testing.T) {
 	t.Parallel()
-	e := NewLatencyMetricsEvent(tag, value, GetEvaluation)
+	e := NewLatencyMetricsEvent(tag, 0.1, GetEvaluation)
 	assert.IsType(t, &LatencyMetricsEvent{}, e)
 	assert.Equal(t, tag, e.Labels["tag"])
-	assert.Equal(t, value, e.Duration.Value)
-	assert.Equal(t, DurationType, e.Duration.Type)
+	assert.Equal(t, 0.1, e.LatencySecond)
 	assert.Equal(t, LatencyMetricsEventType, e.Type)
 }

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -77,13 +77,10 @@ func TestRegisterEvents(t *testing.T) {
 	temetricsEvent, err := json.Marshal(model.NewMetricsEvent(timeoutError))
 	assert.NoError(t, err)
 	latency, err := json.Marshal(&model.LatencyMetricsEvent{
-		APIID:  model.GetEvaluation,
-		Labels: map[string]string{"tag": tag},
-		Duration: &model.Duration{
-			Type:  model.DurationType,
-			Value: "5s",
-		},
-		Type: model.LatencyMetricsEventType,
+		APIID:         model.GetEvaluation,
+		Labels:        map[string]string{"tag": tag},
+		LatencySecond: 0.1,
+		Type:          model.LatencyMetricsEventType,
 	})
 	assert.NoError(t, err)
 	lmetricsEvent, err := json.Marshal(model.NewMetricsEvent(latency))


### PR DESCRIPTION
We currently use LatencySecond field instead of Duration field. See https://github.com/bucketeer-io/bucketeer/commit/1a7d7ad9e6b988056eeeee70cce8bb8a062fc0dc.

## Before
![Screen Shot 2023-06-15 at 19 09 29](https://github.com/ca-dp/bucketeer-go-server-sdk/assets/59436572/2f2e146a-c248-4f7a-ad41-917cf3b34fa5)

## After

![Screen Shot 2023-06-15 at 19 20 28](https://github.com/ca-dp/bucketeer-go-server-sdk/assets/59436572/ddae0f90-21b5-4846-96ed-b832ae986d52)
