### PR TITLE
fix: size metric event is reporting size incorrectly

### DIFF
--- a/pkg/bucketeer/api/api.go
+++ b/pkg/bucketeer/api/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/ca-dp/bucketeer-go-server-sdk/pkg/bucketeer/model"
@@ -22,7 +23,7 @@ func (c *client) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvalu
 		c.host,
 		evaluationAPI,
 	)
-	resp, err := c.sendHTTPRequest(
+	resp, size, err := c.sendHTTPRequest(
 		url,
 		req,
 	)
@@ -33,36 +34,36 @@ func (c *client) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvalu
 	if err := json.Unmarshal(resp, &ger); err != nil {
 		return nil, 0, err
 	}
-	return &ger, len(resp), nil
+	return &ger, size, nil
 }
 
-func (c *client) RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, error) {
+func (c *client) RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, int, error) {
 	url := fmt.Sprintf("https://%s%s",
 		c.host,
 		eventsAPI,
 	)
-	resp, err := c.sendHTTPRequest(
+	resp, size, err := c.sendHTTPRequest(
 		url,
 		req,
 	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	var rer model.RegisterEventsResponse
 	if err := json.Unmarshal(resp, &rer); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return &rer, nil
+	return &rer, size, nil
 }
 
-func (c *client) sendHTTPRequest(url string, body interface{}) ([]byte, error) {
+func (c *client) sendHTTPRequest(url string, body interface{}) ([]byte, int, error) {
 	encoded, err := json.Marshal(body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(encoded))
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	req.Header.Add(authorizationKey, c.apiKey)
 	req.Header.Add("Content-Type", "application/json")
@@ -71,15 +72,33 @@ func (c *client) sendHTTPRequest(url string, body interface{}) ([]byte, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, NewErrStatus(resp.StatusCode)
+		return nil, 0, NewErrStatus(resp.StatusCode)
 	}
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return data, nil
+	size, err := c.getBodySize(resp)
+	if err != nil {
+		return nil, 0, err
+	}
+	return data, size, nil
+}
+
+func (*client) getBodySize(resp *http.Response) (int, error) {
+	// Given keys are case insensitive in `func (Header) Get`.
+	// FYI: https://pkg.go.dev/net/http#Header.Get
+	header := resp.Header.Get("Content-Length")
+	if header == "" {
+		header = "0"
+	}
+	length, err := strconv.Atoi(header)
+	if err != nil {
+		return 0, err
+	}
+	return length, nil
 }

--- a/pkg/bucketeer/api/api.go
+++ b/pkg/bucketeer/api/api.go
@@ -33,7 +33,6 @@ func (c *client) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvalu
 	if err := json.Unmarshal(resp, &ger); err != nil {
 		return nil, 0, err
 	}
-	fmt.Println(len(resp))
 	return &ger, len(resp), nil
 }
 

--- a/pkg/bucketeer/api/api.go
+++ b/pkg/bucketeer/api/api.go
@@ -82,23 +82,5 @@ func (c *client) sendHTTPRequest(url string, body interface{}) ([]byte, int, err
 	if err != nil {
 		return nil, 0, err
 	}
-	size, err := c.getBodySize(resp)
-	if err != nil {
-		return nil, 0, err
-	}
-	return data, size, nil
-}
-
-func (*client) getBodySize(resp *http.Response) (int, error) {
-	// Given keys are case insensitive in `func (Header) Get`.
-	// FYI: https://pkg.go.dev/net/http#Header.Get
-	header := resp.Header.Get("Content-Length")
-	if header == "" {
-		header = "0"
-	}
-	length, err := strconv.Atoi(header)
-	if err != nil {
-		return 0, err
-	}
-	return length, nil
+	return data, int(resp.ContentLength), nil
 }

--- a/pkg/bucketeer/api/api.go
+++ b/pkg/bucketeer/api/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/ca-dp/bucketeer-go-server-sdk/pkg/bucketeer/model"

--- a/pkg/bucketeer/api/api.go
+++ b/pkg/bucketeer/api/api.go
@@ -17,7 +17,7 @@ const (
 	authorizationKey = "authorization"
 )
 
-func (c *client) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, error) {
+func (c *client) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, int, error) {
 	url := fmt.Sprintf("https://%s%s",
 		c.host,
 		evaluationAPI,
@@ -27,13 +27,14 @@ func (c *client) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvalu
 		req,
 	)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	var ger model.GetEvaluationResponse
 	if err := json.Unmarshal(resp, &ger); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return &ger, nil
+	fmt.Println(len(resp))
+	return &ger, len(resp), nil
 }
 
 func (c *client) RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, error) {

--- a/pkg/bucketeer/api/client.go
+++ b/pkg/bucketeer/api/client.go
@@ -5,7 +5,7 @@ import "github.com/ca-dp/bucketeer-go-server-sdk/pkg/bucketeer/model"
 
 // Client is the client interface for the Bucketeer APIGateway service.
 type Client interface {
-	GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, error)
+	GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, int, error)
 	RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, error)
 }
 

--- a/pkg/bucketeer/api/client.go
+++ b/pkg/bucketeer/api/client.go
@@ -6,7 +6,7 @@ import "github.com/ca-dp/bucketeer-go-server-sdk/pkg/bucketeer/model"
 // Client is the client interface for the Bucketeer APIGateway service.
 type Client interface {
 	GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, int, error)
-	RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, error)
+	RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, int, error)
 }
 
 type client struct {

--- a/pkg/bucketeer/event/processor.go
+++ b/pkg/bucketeer/event/processor.go
@@ -405,7 +405,7 @@ func (p *processor) flushEvents(ctx context.Context, events []*model.Event) {
 	if len(events) == 0 {
 		return
 	}
-	res, err := p.apiClient.RegisterEvents(&model.RegisterEventsRequest{Events: events})
+	res, _, err := p.apiClient.RegisterEvents(&model.RegisterEventsRequest{Events: events})
 	if err != nil {
 		p.loggers.Debugf("bucketeer/event: failed to register events: %v", err)
 		// Re-push all events to the event queue.

--- a/pkg/bucketeer/event/processor_test.go
+++ b/pkg/bucketeer/event/processor_test.go
@@ -388,6 +388,7 @@ func TestFlushEvents(t *testing.T) {
 			setup: func(p *processor, events []*model.Event) {
 				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
 					nil,
+					0,
 					api.NewErrStatus(http.StatusInternalServerError),
 				)
 			},
@@ -400,6 +401,7 @@ func TestFlushEvents(t *testing.T) {
 				p.evtQueue.close()
 				p.apiClient.(*mockapi.MockClient).EXPECT().RegisterEvents(&model.RegisterEventsRequest{Events: events}).Return(
 					nil,
+					0,
 					api.NewErrStatus(http.StatusInternalServerError),
 				)
 			},
@@ -416,6 +418,7 @@ func TestFlushEvents(t *testing.T) {
 							"id-1": {Retriable: false, Message: "non retriable"},
 						},
 					},
+					0,
 					nil,
 				)
 			},
@@ -433,6 +436,7 @@ func TestFlushEvents(t *testing.T) {
 							"id-1": {Retriable: false, Message: "non retriable"},
 						},
 					},
+					0,
 					nil,
 				)
 			},
@@ -446,6 +450,7 @@ func TestFlushEvents(t *testing.T) {
 					&model.RegisterEventsResponse{
 						Errors: make(map[string]*model.RegisterEventsResponseError),
 					},
+					0,
 					nil,
 				)
 			},

--- a/pkg/bucketeer/sdk.go
+++ b/pkg/bucketeer/sdk.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strconv"
 	"time"
-	"unsafe"
 
 	"github.com/ca-dp/bucketeer-go-server-sdk/pkg/bucketeer/user"
 
@@ -260,7 +259,7 @@ func (s *sdk) callGetEvaluationAPI(
 		measure(ctx, time.Since(reqStart))
 	}()
 
-	res, err := s.apiClient.GetEvaluation(model.NewGetEvaluationRequest(
+	res, size, err := s.apiClient.GetEvaluation(model.NewGetEvaluationRequest(
 		tag, featureID,
 		user,
 	))
@@ -269,7 +268,7 @@ func (s *sdk) callGetEvaluationAPI(
 		return nil, fmt.Errorf("failed to get evaluation: %w", err)
 	}
 	s.eventProcessor.PushLatencyMetricsEvent(ctx, time.Since(reqStart), model.GetEvaluation)
-	s.eventProcessor.PushSizeMetricsEvent(ctx, int(unsafe.Sizeof(res)), model.GetEvaluation)
+	s.eventProcessor.PushSizeMetricsEvent(ctx, size, model.GetEvaluation)
 	return res, nil
 }
 

--- a/pkg/bucketeer/sdk_test.go
+++ b/pkg/bucketeer/sdk_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"testing"
-	"unsafe"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +48,7 @@ func TestBoolVariation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
 					ctx,
@@ -77,7 +76,7 @@ func TestBoolVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "invalid")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -85,7 +84,7 @@ func TestBoolVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
@@ -109,7 +108,7 @@ func TestBoolVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "true")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -117,7 +116,7 @@ func TestBoolVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushEvaluationEvent(
@@ -169,7 +168,7 @@ func TestIntVariation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
 					ctx,
@@ -197,7 +196,7 @@ func TestIntVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "invalid")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -205,7 +204,7 @@ func TestIntVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					10,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
@@ -229,7 +228,7 @@ func TestIntVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "2")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 20, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -237,7 +236,7 @@ func TestIntVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					20,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushEvaluationEvent(
@@ -289,6 +288,7 @@ func TestInt64Variation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
+					100,
 					err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
@@ -317,7 +317,7 @@ func TestInt64Variation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "invalid")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 5, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -325,7 +325,7 @@ func TestInt64Variation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					5,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
@@ -349,7 +349,7 @@ func TestInt64Variation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "2")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 10, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -357,7 +357,7 @@ func TestInt64Variation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					10,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushEvaluationEvent(
@@ -409,7 +409,7 @@ func TestFloat64Variation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
 					ctx,
@@ -437,7 +437,7 @@ func TestFloat64Variation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "invalid")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -445,7 +445,7 @@ func TestFloat64Variation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
@@ -469,7 +469,7 @@ func TestFloat64Variation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "2.2")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -477,7 +477,7 @@ func TestFloat64Variation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushEvaluationEvent(
@@ -529,7 +529,7 @@ func TestStringVariation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
 					ctx,
@@ -557,7 +557,7 @@ func TestStringVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "value")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -565,7 +565,7 @@ func TestStringVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushEvaluationEvent(
@@ -621,7 +621,7 @@ func TestJSONVariation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
 					ctx,
@@ -649,7 +649,7 @@ func TestJSONVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, `invalid`)
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -657,7 +657,7 @@ func TestJSONVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushDefaultEvaluationEvent(
@@ -681,7 +681,7 @@ func TestJSONVariation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, `{"str": "str2", "int": "int2"}`)
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -689,7 +689,7 @@ func TestJSONVariation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushEvaluationEvent(
@@ -749,7 +749,7 @@ func TestGetEvaluation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushErrorEvent(
 					ctx,
@@ -774,7 +774,7 @@ func TestGetEvaluation(t *testing.T) {
 				}
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					nil,
-					err,
+					100, err,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushErrorEvent(
 					ctx,
@@ -797,7 +797,7 @@ func TestGetEvaluation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				var res *model.GetEvaluationResponse
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -805,7 +805,7 @@ func TestGetEvaluation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 			},
@@ -825,7 +825,7 @@ func TestGetEvaluation(t *testing.T) {
 				}
 				res := newGetEvaluationResponse(t, featureID, "value")
 				res.Evaluation = nil
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -833,7 +833,7 @@ func TestGetEvaluation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 			},
@@ -852,7 +852,7 @@ func TestGetEvaluation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, "invalid-feature-id", "value")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -860,7 +860,7 @@ func TestGetEvaluation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 			},
@@ -879,7 +879,7 @@ func TestGetEvaluation(t *testing.T) {
 					SourceID:  SourceIDGoServer,
 				}
 				res := newGetEvaluationResponse(t, featureID, "")
-				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, nil)
+				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(res, 100, nil)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
 					ctx,
 					gomock.Any(), // duration
@@ -887,7 +887,7 @@ func TestGetEvaluation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 			},
@@ -908,6 +908,7 @@ func TestGetEvaluation(t *testing.T) {
 				res := newGetEvaluationResponse(t, featureID, "value")
 				s.apiClient.(*mockapi.MockClient).EXPECT().GetEvaluation(req).Return(
 					res,
+					100,
 					nil,
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushLatencyMetricsEvent(
@@ -917,7 +918,7 @@ func TestGetEvaluation(t *testing.T) {
 				)
 				s.eventProcessor.(*mockevent.MockProcessor).EXPECT().PushSizeMetricsEvent(
 					ctx,
-					int(unsafe.Sizeof(res)),
+					100,
 					model.GetEvaluation,
 				)
 			},

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -17,7 +17,7 @@ func TestGetEvaluation(t *testing.T) {
 	t.Parallel()
 	client := newAPIClient(t)
 	user := user.NewUser(userID, nil)
-	res, err := client.GetEvaluation(&model.GetEvaluationRequest{Tag: tag, User: user, FeatureID: featureID})
+	res, _, err := client.GetEvaluation(&model.GetEvaluationRequest{Tag: tag, User: user, FeatureID: featureID})
 	assert.NoError(t, err)
 	assert.Equal(t, featureID, res.Evaluation.FeatureID)
 	assert.Equal(t, featureIDVariation2, res.Evaluation.VariationValue)

--- a/test/e2e/api_test.go
+++ b/test/e2e/api_test.go
@@ -132,7 +132,7 @@ func TestRegisterEvents(t *testing.T) {
 			},
 		},
 	}
-	res, err := client.RegisterEvents(req)
+	res, _, err := client.RegisterEvents(req)
 	assert.NoError(t, err)
 	assert.Len(t, res.Errors, 0)
 }

--- a/test/mock/api/client.go
+++ b/test/mock/api/client.go
@@ -36,12 +36,13 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // GetEvaluation mocks base method.
-func (m *MockClient) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, error) {
+func (m *MockClient) GetEvaluation(req *model.GetEvaluationRequest) (*model.GetEvaluationResponse, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEvaluation", req)
 	ret0, _ := ret[0].(*model.GetEvaluationResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetEvaluation indicates an expected call of GetEvaluation.

--- a/test/mock/api/client.go
+++ b/test/mock/api/client.go
@@ -52,12 +52,13 @@ func (mr *MockClientMockRecorder) GetEvaluation(req interface{}) *gomock.Call {
 }
 
 // RegisterEvents mocks base method.
-func (m *MockClient) RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, error) {
+func (m *MockClient) RegisterEvents(req *model.RegisterEventsRequest) (*model.RegisterEventsResponse, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterEvents", req)
 	ret0, _ := ret[0].(*model.RegisterEventsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // RegisterEvents indicates an expected call of RegisterEvents.

--- a/test/mock/event/processor.go
+++ b/test/mock/event/processor.go
@@ -64,6 +64,18 @@ func (mr *MockProcessorMockRecorder) PushDefaultEvaluationEvent(ctx, user, featu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushDefaultEvaluationEvent", reflect.TypeOf((*MockProcessor)(nil).PushDefaultEvaluationEvent), ctx, user, featureID)
 }
 
+// PushErrorEvent mocks base method.
+func (m *MockProcessor) PushErrorEvent(ctx context.Context, err error, api model.APIID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PushErrorEvent", ctx, err, api)
+}
+
+// PushErrorEvent indicates an expected call of PushErrorEvent.
+func (mr *MockProcessorMockRecorder) PushErrorEvent(ctx, err, api interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushErrorEvent", reflect.TypeOf((*MockProcessor)(nil).PushErrorEvent), ctx, err, api)
+}
+
 // PushEvaluationEvent mocks base method.
 func (m *MockProcessor) PushEvaluationEvent(ctx context.Context, user *user.User, evaluation *model.Evaluation) {
 	m.ctrl.T.Helper()
@@ -110,16 +122,4 @@ func (m *MockProcessor) PushSizeMetricsEvent(ctx context.Context, sizeByte int, 
 func (mr *MockProcessorMockRecorder) PushSizeMetricsEvent(ctx, sizeByte, api interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushSizeMetricsEvent", reflect.TypeOf((*MockProcessor)(nil).PushSizeMetricsEvent), ctx, sizeByte, api)
-}
-
-// PushErrorEvent mocks base method.
-func (m *MockProcessor) PushErrorEvent(ctx context.Context, err error, api model.APIID) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PushErrorEvent", ctx, err, api)
-}
-
-// PushErrorEvent indicates an expected call of PushErrorEvent.
-func (mr *MockProcessorMockRecorder) PushErrorEvent(ctx, err, api interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushErrorEvent", reflect.TypeOf((*MockProcessor)(nil).PushErrorEvent), ctx, err, api)
 }


### PR DESCRIPTION
unsafe.Sizeof does not measure the response. FYI: https://go.dev/play/p/BR3_h6dY4Tp

## Before
![Screen Shot 2023-06-15 at 19 09 48](https://github.com/ca-dp/bucketeer-go-server-sdk/assets/59436572/ce2bf4ef-434a-430e-b311-c30b24b86aaf)


## After

![Screen Shot 2023-06-15 at 19 22 53](https://github.com/ca-dp/bucketeer-go-server-sdk/assets/59436572/920e19b8-1f4c-4407-9d78-eb5635cf38cf)
